### PR TITLE
Add TypeScript codegen options and type guards

### DIFF
--- a/Docs/vul-fields.md
+++ b/Docs/vul-fields.md
@@ -460,6 +460,21 @@ If reference tracking is enabled, exported schemas (both TypeScript and JSON) wi
 support for shared instances via the `VulFieldRef` type. This ensures compatibility with
 deserialization behaviors where objects are shared or cyclic.
 
+### TypeScript Options
+
+TypeScript definitions can be customised when calling `TypeScriptDefinitions()`
+via `FVulFieldTypeScriptOptions`.
+
+The first available option is `GenerateTypeGuardFunctions`. When enabled,
+derived types that use a discriminator field include an exported type guard
+function:
+
+```ts
+export function is<DerivedTypeName>(object: any): object is <DerivedTypeName> {
+    return object.<DiscriminatorField> === <DiscriminatorValue>;
+}
+```
+
 ### Limitations
 
 * TypeScript export only includes known types registered via `VULFLD_` macros.

--- a/Docs/vul-fields.md
+++ b/Docs/vul-fields.md
@@ -465,13 +465,12 @@ deserialization behaviors where objects are shared or cyclic.
 TypeScript definitions can be customised when calling `TypeScriptDefinitions()`
 via `FVulFieldTypeScriptOptions`.
 
-The first available option is `GenerateTypeGuardFunctions`. When enabled,
-derived types that use a discriminator field include an exported type guard
-function:
+`DiscriminatorTypeGuardFunctions`. When enabled, derived types that use a discriminator 
+field include an exported type guard function:
 
 ```ts
-export function is<DerivedTypeName>(object: any): object is <DerivedTypeName> {
-    return object.<DiscriminatorField> === <DiscriminatorValue>;
+export function isMyVulFieldType(object: any): object is MyVulFieldType {
+    return object.MyVulDiscriminatorField === MyVulDiscriminatorFieldEnum.MyVulDiscriminatorFieldValue;
 }
 ```
 

--- a/Source/VulRuntime/Private/Field/Tests/TestVulFieldMeta.cpp
+++ b/Source/VulRuntime/Private/Field/Tests/TestVulFieldMeta.cpp
@@ -288,9 +288,9 @@ bool TestVulFieldMeta::RunTest(const FString& Parameters)
 		
 		(void)TC.JsonObjectsEqual(JsonSchema, Expected);
 	});
-	
-        VulTest::Case(this, "Typescript definitions", [](VulTest::TC TC)
-        {
+
+	VulTest::Case(this, "Typescript definitions", [](VulTest::TC TC)
+	{
 		TSharedPtr<FVulFieldTestTreeBase> Base;
 		FMyStringAlias StrAlias;
 		UVulFieldTestUObject1* Obj;
@@ -346,35 +346,32 @@ export interface VulFieldTestUObject2 {
 }
 )";
 
-                const auto Actual = Desc->TypeScriptDefinitions();
+		const auto Actual = Desc->TypeScriptDefinitions();
+		
+		(void)TC.EqualNoWhitespace(Actual, Expected, "typescript definition match");
+	});
 
-		if (!TC.EqualNoWhitespace(Actual, Expected, "typescript definition match"))
-		{
-			return;
-		}
-        });
+	VulTest::Case(this, "Typescript definitions - type guard functions", [](VulTest::TC TC)
+	{
+		TSharedPtr<FVulFieldTestTreeBase> Base;
+		FMyStringAlias StrAlias;
+		UVulFieldTestUObject1* Obj;
+		FVulSingleFieldType SingleFieldType;
 
-        VulTest::Case(this, "Typescript definitions - type guard functions", [](VulTest::TC TC)
-        {
-                TSharedPtr<FVulFieldTestTreeBase> Base;
-                FMyStringAlias StrAlias;
-                UVulFieldTestUObject1* Obj;
-                FVulSingleFieldType SingleFieldType;
+		FVulFieldSet Set;
+		Set.Add(FVulField::Create(&Base), "base");
+		Set.Add(FVulField::Create(&StrAlias), "strAlias");
+		Set.Add(FVulField::Create(&Obj), "uObject");
+		Set.Add(FVulField::Create(&SingleFieldType), "singleField");
 
-                FVulFieldSet Set;
-                Set.Add(FVulField::Create(&Base), "base");
-                Set.Add(FVulField::Create(&StrAlias), "strAlias");
-                Set.Add(FVulField::Create(&Obj), "uObject");
-                Set.Add(FVulField::Create(&SingleFieldType), "singleField");
+		FVulFieldSerializationContext Ctx;
+		TSharedPtr<FVulFieldDescription> Desc = MakeShared<FVulFieldDescription>();
+		VTC_MUST_EQUAL(true, TestDescribe(TC, Set, Ctx, Desc), "");
 
-                FVulFieldSerializationContext Ctx;
-                TSharedPtr<FVulFieldDescription> Desc = MakeShared<FVulFieldDescription>();
-                VTC_MUST_EQUAL(true, TestDescribe(TC, Set, Ctx, Desc), "");
+		FVulFieldTypeScriptOptions Opts;
+		Opts.DiscriminatorTypeGuardFunctions = true;
 
-                FVulFieldTypeScriptOptions Opts;
-                Opts.GenerateTypeGuardFunctions = true;
-
-                FString Expected = R"(
+		FString Expected = R"(
 // A string reference to an existing object of the given type
 // @ts-ignore
 export type VulFieldRef<T> = string;
@@ -384,51 +381,48 @@ export type SingleFieldType = number;
 export type StringAlias = string;
 
 export interface VulFieldTestTreeBase {
-type?: VulFieldTestTreeNodeType;
-children?: VulFieldTestTreeBase[];
+	type?: VulFieldTestTreeNodeType;
+	children?: VulFieldTestTreeBase[];
 }
 
 export interface VulFieldTestTreeNode1 extends VulFieldTestTreeBase {
-type: VulFieldTestTreeNodeType.Node1;
-int?: number;
+	type: VulFieldTestTreeNodeType.Node1;
+	int?: number;
 }
 
 export function isVulFieldTestTreeNode1(object: any): object is VulFieldTestTreeNode1 {
-return object.type === "Node1";
+	return object.type === "Node1";
 }
 
 export interface VulFieldTestTreeNode2 extends VulFieldTestTreeBase {
-type: VulFieldTestTreeNodeType.Node2;
-str?: string;
+	type: VulFieldTestTreeNodeType.Node2;
+	str?: string;
 }
 
 export function isVulFieldTestTreeNode2(object: any): object is VulFieldTestTreeNode2 {
-return object.type === "Node2";
+	return object.type === "Node2";
 }
 
 export enum VulFieldTestTreeNodeType {
-Base = "Base",
-Node1 = "Node1",
-Node2 = "Node2",
+	Base = "Base",
+	Node1 = "Node1",
+	Node2 = "Node2",
 }
 
 export interface VulFieldTestUObject1 {
-str?: string;
-obj?: (VulFieldTestUObject2 | VulFieldRef<VulFieldTestUObject2>);
+	str?: string;
+	obj?: (VulFieldTestUObject2 | VulFieldRef<VulFieldTestUObject2>);
 }
 
 export interface VulFieldTestUObject2 {
-str?: string;
+	str?: string;
 }
 )";
 
-                const auto Actual = Desc->TypeScriptDefinitions(Opts);
+		const auto Actual = Desc->TypeScriptDefinitions(Opts);
 
-                if (!TC.EqualNoWhitespace(Actual, Expected, "typescript definition match"))
-                {
-                        return;
-                }
-        });
+		(void)TC.EqualNoWhitespace(Actual, Expected, "typescript definition match");
+	});
 	
 	VulTest::Case(this, "Typescript definitions - UINTERFACES", [](VulTest::TC TC)
 	{

--- a/Source/VulRuntime/Public/Field/VulFieldMeta.h
+++ b/Source/VulRuntime/Public/Field/VulFieldMeta.h
@@ -2,6 +2,7 @@
 
 #include "Field/VulFieldUtil.h"
 #include "VulFieldSerializationContext.h"
+#include "VulFieldTypeScriptOptions.h"
 
 /**
  * Describes a Vul serializable field.
@@ -96,7 +97,7 @@ struct VULRUNTIME_API FVulFieldDescription
 
 	TOptional<FString> GetTypeId() const { return TypeId; }
 
-	FString TypeScriptDefinitions() const;
+       FString TypeScriptDefinitions(const FVulFieldTypeScriptOptions& Options = FVulFieldTypeScriptOptions()) const;
 
 	/**
 	 * Extracts all descriptions that are named types, i.e. registered with FVulFieldRegistry.

--- a/Source/VulRuntime/Public/Field/VulFieldTypeScriptOptions.h
+++ b/Source/VulRuntime/Public/Field/VulFieldTypeScriptOptions.h
@@ -3,13 +3,15 @@
 #include "CoreMinimal.h"
 #include "VulRuntime.h"
 
-/** Options to customize TypeScript definition generation. */
+/**
+ * Options to customize TypeScript definition generation.
+ */
 struct VULRUNTIME_API FVulFieldTypeScriptOptions
 {
-    /**
-     * If true, generate exported type guard functions for types with
-     * discriminator fields.
-     */
-    bool GenerateTypeGuardFunctions = false;
+	/**
+	 * If true, generate exported type guard functions for types with
+	 * discriminator fields.
+	 */
+	bool DiscriminatorTypeGuardFunctions = false;
 };
 

--- a/Source/VulRuntime/Public/Field/VulFieldTypeScriptOptions.h
+++ b/Source/VulRuntime/Public/Field/VulFieldTypeScriptOptions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "VulRuntime.h"
+
+/** Options to customize TypeScript definition generation. */
+struct VULRUNTIME_API FVulFieldTypeScriptOptions
+{
+    /**
+     * If true, generate exported type guard functions for types with
+     * discriminator fields.
+     */
+    bool GenerateTypeGuardFunctions = false;
+};
+


### PR DESCRIPTION
## Summary
- add `FVulFieldTypeScriptOptions` struct
- support optional type guard generation in `TypeScriptDefinitions()`
- test new option
- document TypeScript options

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849cc6926e88325a99e3b1289203f86